### PR TITLE
Fixed broken router transitions/animations

### DIFF
--- a/projects/angular-ngrx-material-starter/src/app/core/animations/route.animations.ts
+++ b/projects/angular-ngrx-material-starter/src/app/core/animations/route.animations.ts
@@ -12,6 +12,9 @@ import { AnimationsService } from './animations.service';
 export const ROUTE_ANIMATIONS_ELEMENTS = 'route-animations-elements';
 
 const STEPS_ALL: any[] = [
+  query(':leave > *', style({opacity: 1, position: 'static'}), {
+    optional: true
+  }),
   query(':enter > *', style({ opacity: 0, position: 'fixed' }), {
     optional: true
   }),
@@ -45,7 +48,11 @@ const STEPS_ALL: any[] = [
         )
       ],
       { optional: true }
-    )
+    ),
+    query(':enter > *', [
+          style({position: 'static'})
+        ],
+        {optional: true})
   ]),
   query(
     ':enter .' + ROUTE_ANIMATIONS_ELEMENTS,
@@ -60,8 +67,8 @@ const STEPS_ALL: any[] = [
   )
 ];
 const STEPS_NONE = [];
-const STEPS_PAGE = [STEPS_ALL[0], STEPS_ALL[2]];
-const STEPS_ELEMENTS = [STEPS_ALL[1], STEPS_ALL[3]];
+const STEPS_PAGE = [STEPS_ALL[0], STEPS_ALL[1], STEPS_ALL[3]];
+const STEPS_ELEMENTS = [STEPS_ALL[2], STEPS_ALL[4]];
 
 export const routeAnimations = trigger('routeAnimations', [
   transition(isRouteAnimationsAll, STEPS_ALL),


### PR DESCRIPTION
Fixed the animations for the router transitions which are broken in Safari and Edge because a inline style from the animation "position: fixed" was not properly removed.

Closes: #495
Closes: #493
